### PR TITLE
Add methods to get current open range start/end

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,24 @@ Carbon::nextClose()       // go to next close time from now
 $carbonDate->nextClose()  // go to next close time from $carbonDate
 ``` 
 
+### previousOpen
+
+Go to previous open-business time.
+
+```php
+Carbon::previousOpen()       // go to previous open time from now
+$carbonDate->previousOpen()  // go to previous open time from $carbonDate
+``` 
+
+### previousClose
+
+Go to previous closed-business time.
+
+```php
+Carbon::previousClose()       // go to previous close time from now
+$carbonDate->previousClose()  // go to previous close time from $carbonDate
+``` 
+
 ### getCurrentDayOpeningHours
 
 Returns the opening hours current day settings (first matching exception or else current weekday settings).
@@ -274,6 +292,28 @@ exception for a finest setting. [See Holidays section](#Holidays)
 Carbon::setHolidaysRegion('us-national');
 echo Carbon::nextBusinessClose();
 echo $carbonDate->nextBusinessClose();
+``` 
+
+### previousBusinessOpen / previousOpenExcludingHolidays
+
+Go to previous open time (considering all holidays as closed time). But prefer to handle holidays with a dedicated
+exception for a finest setting. [See Holidays section](#Holidays)
+
+```php
+Carbon::setHolidaysRegion('us-national');
+echo Carbon::previousBusinessOpen();
+echo $carbonDate->previousBusinessOpen();
+``` 
+
+### previousBusinessClose / previousCloseIncludingHolidays
+
+Go to previous closed time (considering all holidays as closed time). But prefer to handle holidays with a dedicated
+exception for a finest setting. [See Holidays section](#Holidays)
+
+```php
+Carbon::setHolidaysRegion('us-national');
+echo Carbon::previousBusinessClose();
+echo $carbonDate->previousBusinessClose();
 ``` 
 
 ### Laravel

--- a/README.md
+++ b/README.md
@@ -316,6 +316,125 @@ echo Carbon::previousBusinessClose();
 echo $carbonDate->previousBusinessClose();
 ``` 
 
+### getCurrentOpenTimeRanges
+
+Get list of ranges that contain the current date-time.
+
+```php
+foreach (Carbon::getCurrentOpenTimeRanges() as $timeRange) {
+  echo 'From: '.$timeRange->start().' to '.$timeRange->end()."\n";
+}
+foreach ($carbonDate->getCurrentOpenTimeRanges() as $timeRange) {
+  echo 'From: '.$timeRange->start().' to '.$timeRange->end()."\n";
+}
+``` 
+
+### getCurrentOpenTimeRange
+
+Get the first range that contain the current date-time.
+
+```php
+$timeRange = Carbon::getCurrentOpenTimeRange();
+
+if ($timeRange) {
+  echo 'From: '.$timeRange->start().' to '.$timeRange->end()."\n";
+}
+
+$timeRange = $carbonDate->getCurrentOpenTimeRange();
+
+if ($timeRange) {
+  echo 'From: '.$timeRange->start().' to '.$timeRange->end()."\n";
+}
+``` 
+
+### getCurrentOpenTimeRangeStart
+
+Get the start of the current open time range (if open, holidays ignored).
+
+```php
+$start = Carbon::getCurrentOpenTimeRangeStart();
+
+if ($start) {
+  echo 'Open since '.$start->format('l H:i')."\n";
+} else {
+  echo "Closed\n";
+}
+
+$start = $carbonDate->getCurrentOpenTimeRangeStart();
+
+if ($start) {
+  echo 'Open since '.$start->format('l H:i')."\n";
+} else {
+   echo "Closed\n";
+ }
+``` 
+
+### getCurrentOpenTimeRangeEnd
+
+Get the end of the current open time range (if open, holidays ignored).
+
+```php
+$end = Carbon::getCurrentOpenTimeRangeEnd();
+
+if ($end) {
+  echo 'Will close at '.$start->format('l H:i')."\n";
+} else {
+  echo "Closed\n";
+}
+
+$end = $carbonDate->getCurrentOpenTimeRangeEnd();
+
+if ($end) {
+  echo 'Will close at '.$start->format('l H:i')."\n";
+} else {
+   echo "Closed\n";
+ }
+``` 
+
+### getCurrentBusinessTimeRangeStart
+
+Get the start of the current open time range (if open and not holiday).
+
+```php
+$start = Carbon::getCurrentBusinessTimeRangeStart();
+
+if ($start) {
+  echo 'Open since '.$start->format('l H:i')."\n";
+} else {
+  echo "Closed\n";
+}
+
+$start = $carbonDate->getCurrentBusinessTimeRangeStart();
+
+if ($start) {
+  echo 'Open since '.$start->format('l H:i')."\n";
+} else {
+   echo "Closed\n";
+ }
+``` 
+
+### getCurrentBusinessTimeRangeEnd
+
+Get the end of the current open time range (if open and not holiday).
+
+```php
+$end = Carbon::getCurrentBusinessTimeRangeEnd();
+
+if ($end) {
+  echo 'Will close at '.$start->format('l H:i')."\n";
+} else {
+  echo "Closed\n";
+}
+
+$end = $carbonDate->getCurrentBusinessTimeRangeEnd();
+
+if ($end) {
+  echo 'Will close at '.$start->format('l H:i')."\n";
+} else {
+   echo "Closed\n";
+ }
+``` 
+
 ### Laravel
 
 To enable business-time globally in Laravel, set default openning hours and holidays settings in the config file

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "spatie/opening-hours": "^2.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0 || ^7.0"
+    "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "php": ">=7.1",
     "cmixin/business-day": "^1.1",
     "nesbot/carbon": "^2.0",
-    "spatie/opening-hours": "^2.0"
+    "spatie/opening-hours": "^2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0 || ^7.0"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
     <filter>
         <whitelist>
             <directory>src/Cmixin</directory>
+            <directory>src/BusinessTime</directory>
         </whitelist>
     </filter>
 

--- a/src/BusinessTime/MixinBase.php
+++ b/src/BusinessTime/MixinBase.php
@@ -11,8 +11,12 @@ class MixinBase extends BusinessDay
 {
     const NEXT_OPEN_METHOD = 'nextOpen';
     const NEXT_CLOSE_METHOD = 'nextClose';
+    const PREVIOUS_OPEN_METHOD = 'previousOpen';
+    const PREVIOUS_CLOSE_METHOD = 'previousClose';
     const NEXT_OPEN_HOLIDAYS_METHOD = 'nextOpenExcludingHolidays';
     const NEXT_CLOSE_HOLIDAYS_METHOD = 'nextCloseIncludingHolidays';
+    const PREVIOUS_OPEN_HOLIDAYS_METHOD = 'previousOpenExcludingHolidays';
+    const PREVIOUS_CLOSE_HOLIDAYS_METHOD = 'previousCloseIncludingHolidays';
     const CURRENT_OPEN_RANGE_START_METHOD = 'currentOpenRangeStart';
     const CURRENT_OPEN_RANGE_END_METHOD = 'currentOpenRangeEnd';
 

--- a/src/BusinessTime/MixinBase.php
+++ b/src/BusinessTime/MixinBase.php
@@ -300,12 +300,11 @@ class MixinBase extends BusinessDay
      * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
      * return a date, then convert it into a Carbon/sub-class instance.
      *
-     * @param string     $callee
-     * @param array|null $earlyReturn
+     * @param string $callee
      *
      * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
      */
-    public function getCalleeAsMethod($callee = null, $earlyReturn = null)
+    public function getCalleeAsMethod($callee = null)
     {
         /**
          * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
@@ -315,17 +314,9 @@ class MixinBase extends BusinessDay
          *
          * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
          */
-        return function ($method = null) use ($callee, $earlyReturn) {
+        return function ($method = null) use ($callee) {
             $method = is_string($method) ? $method : $callee;
             $date = isset($this) ? $this : static::now();
-
-            if ($earlyReturn) {
-                [$method, $value] = $earlyReturn;
-
-                if ($date->$method()) {
-                    return $value;
-                }
-            }
 
             if (isset($this)) {
                 /* @var \Carbon\Carbon|static $this */

--- a/src/BusinessTime/Traits/IsMethods.php
+++ b/src/BusinessTime/Traits/IsMethods.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace BusinessTime\Traits;
+
+trait IsMethods
+{
+    /**
+     * Returns true if the business is open on a given day according to current opening hours.
+     *
+     * @param string $method can be null or 'isClosedOn' to invert the result
+     *
+     * @return \Closure<bool>
+     */
+    public function isOpenOn($method = null)
+    {
+        $method = preg_replace('/^.*::/', '', $method ?: __METHOD__);
+
+        /**
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        return function ($day) use ($method) {
+            $day = static::normalizeDay($day);
+            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
+
+            return $openingHours->$method($day);
+        };
+    }
+
+    /**
+     * Returns true if the business is closed on a given day according to current opening hours.
+     *
+     * @return \Closure<bool>
+     */
+    public function isClosedOn()
+    {
+        /**
+         * Returns true if the business is closed on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        return $this->isOpenOn(__METHOD__);
+    }
+
+    /**
+     * Returns true if the business is open now (or current date and time) according to current opening hours.
+     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @param string $method can be null or 'isClosed' to invert the result
+     *
+     * @return \Closure<bool>
+     */
+    public function isOpen($method = null)
+    {
+        $method = preg_replace('/^.*::/', '', $method ?: __METHOD__).'At';
+
+        /**
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        return function () use ($method) {
+            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
+            $date = isset($this) ? $this : static::now();
+
+            return $openingHours->$method($date);
+        };
+    }
+
+    /**
+     * Returns true if the business is closed now (or current date and time) according to current opening hours.
+     * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<bool>
+     */
+    public function isClosed()
+    {
+        /**
+         * Returns true if the business is closed now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        return $this->isOpen(__METHOD__);
+    }
+
+    /**
+     * Returns true if the business is open and not an holiday now (or current date and time) according to current
+     * opening hours.
+     *
+     * @return \Closure<bool>
+     */
+    public function isBusinessOpen()
+    {
+        /**
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        return function () {
+            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
+            $date = isset($this) ? $this : static::now();
+
+            return $openingHours->isOpenAt($date) && !$date->isHoliday();
+        };
+    }
+
+    /**
+     * @alias isBusinessOpen
+     *
+     * Returns true if the business is open and not an holiday now (or current date and time) according to current
+     * opening hours.
+     *
+     * @return \Closure<bool>
+     */
+    public function isOpenExcludingHolidays()
+    {
+        /**
+         * @alias isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        return $this->isBusinessOpen();
+    }
+
+    /**
+     * Returns true if the business is closed or an holiday now (or current date and time) according to current
+     * opening hours.
+     *
+     * @return \Closure<bool>
+     */
+    public function isBusinessClosed()
+    {
+        /**
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        return function () {
+            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
+            $date = isset($this) ? $this : static::now();
+
+            return $openingHours->isClosedAt($date) || $date->isHoliday();
+        };
+    }
+
+    /**
+     * @alias isBusinessClosed
+     *
+     * Returns true if the business is closed or an holiday now (or current date and time) according to current
+     * opening hours.
+     *
+     * @return \Closure<bool>
+     */
+    public function isClosedIncludingHolidays()
+    {
+        /**
+         * @alias isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        return $this->isBusinessClosed();
+    }
+}

--- a/src/BusinessTime/Traits/OpenClose.php
+++ b/src/BusinessTime/Traits/OpenClose.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BusinessTime\Traits;
+
+trait OpenClose
+{
+    /**
+     * Go to the next open date and time.
+     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function nextOpen()
+    {
+        /**
+         * Go to the next open date and time.
+         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getCalleeAsMethod(static::NEXT_OPEN_METHOD);
+    }
+
+    /**
+     * Go to the next close date and time.
+     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function nextClose()
+    {
+        /**
+         * Go to the next close date and time.
+         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getCalleeAsMethod(static::NEXT_CLOSE_METHOD);
+    }
+
+    /**
+     * Go to the previous open date and time.
+     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousOpen()
+    {
+        /**
+         * Go to the previous open date and time.
+         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getCalleeAsMethod(static::PREVIOUS_OPEN_METHOD);
+    }
+
+    /**
+     * Go to the previous close date and time.
+     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousClose()
+    {
+        /**
+         * Go to the previous close date and time.
+         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getCalleeAsMethod(static::PREVIOUS_CLOSE_METHOD);
+    }
+}

--- a/src/BusinessTime/Traits/Range.php
+++ b/src/BusinessTime/Traits/Range.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace BusinessTime\Traits;
+
+use Carbon\Carbon;
+
+trait Range
+{
+    /**
+     * Get OpeningHoursForDay instance of the current instance or class.
+     *
+     * @return \Closure<\Spatie\OpeningHours\OpeningHoursForDay>
+     */
+    public function getCurrentDayOpeningHours()
+    {
+        /**
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        return function () {
+            /** @var Carbon $date */
+            $date = isset($this) ? $this : static::now();
+
+            return $date->getOpeningHours()->forDate($date);
+        };
+    }
+
+    /**
+     * Get open time ranges as array of TimeRange instances that matches the current date and time.
+     *
+     * @return \Closure<\Spatie\OpeningHours\TimeRange[]>
+     */
+    public function getCurrentOpenTimeRanges()
+    {
+        /**
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        return function () {
+            /** @var Carbon $date */
+            $date = isset($this) ? $this : static::now();
+
+            return $date->getOpeningHours()->forDateTime($date);
+        };
+    }
+
+    /**
+     * Get current open time range as TimeRange instance or false if closed.
+     *
+     * @return \Closure<\Spatie\OpeningHours\TimeRange|bool>
+     */
+    public function getCurrentOpenTimeRange()
+    {
+        /**
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        return function () {
+            /** @var Carbon $date */
+            $date = isset($this) ? $this : static::now();
+
+            return $date->getOpeningHours()->currentOpenRange($date);
+        };
+    }
+
+    /**
+     * Get current open time range start as Carbon instance or false if closed.
+     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentOpenTimeRangeStart()
+    {
+        /**
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD);
+    }
+
+    /**
+     * Get current open time range end as Carbon instance or false if closed.
+     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentOpenTimeRangeEnd()
+    {
+        /**
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD);
+    }
+
+    /**
+     * Get current open time range start as Carbon instance or false if closed or holiday.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentBusinessTimeRangeStart()
+    {
+        /**
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD, ['isHoliday', false]);
+    }
+
+    /**
+     * Get current open time range end as Carbon instance or false if closed.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentBusinessOpenTimeRangeEnd()
+    {
+        /**
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD, ['isHoliday', false]);
+    }
+}

--- a/src/Cmixin/BusinessTime.php
+++ b/src/Cmixin/BusinessTime.php
@@ -3,9 +3,9 @@
 namespace Cmixin;
 
 use BusinessTime\MixinBase;
-use BusinessTime\Traits\Range;
 use BusinessTime\Traits\IsMethods;
 use BusinessTime\Traits\OpenClose;
+use BusinessTime\Traits\Range;
 
 class BusinessTime extends MixinBase
 {

--- a/src/Cmixin/BusinessTime.php
+++ b/src/Cmixin/BusinessTime.php
@@ -7,22 +7,128 @@ use BusinessTime\MixinBase;
 class BusinessTime extends MixinBase
 {
     /**
-     * Get OpeningHours instance of the current instance or class.
+     * Get OpeningHoursForDay instance of the current instance or class.
      *
-     * @return \Closure<\Spatie\OpeningHours\OpeningHours>
+     * @return \Closure<\Spatie\OpeningHours\OpeningHoursForDay>
      */
     public function getCurrentDayOpeningHours()
     {
         /**
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         return function () {
             $date = isset($this) ? $this : static::now();
 
             return $date->getOpeningHours()->forDate($date);
         };
+    }
+
+    /**
+     * Get open time ranges as array of TimeRange instances that matches the current date and time.
+     *
+     * @return \Closure<\Spatie\OpeningHours\TimeRange[]>
+     */
+    public function getCurrentOpenTimeRanges()
+    {
+        /**
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        return function () {
+            $date = isset($this) ? $this : static::now();
+
+            return $date->getOpeningHours()->forDateTime($date);
+        };
+    }
+
+    /**
+     * Get current open time range as TimeRange instance or false if closed.
+     *
+     * @return \Closure<\Spatie\OpeningHours\TimeRange|bool>
+     */
+    public function getCurrentOpenTimeRange()
+    {
+        /**
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        return function () {
+            $date = isset($this) ? $this : static::now();
+
+            return $date->getOpeningHours()->currentOpenRange($date);
+        };
+    }
+
+    /**
+     * Get current open time range start as Carbon instance or false if closed.
+     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentOpenTimeRangeStart()
+    {
+        /**
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD);
+    }
+
+    /**
+     * Get current open time range end as Carbon instance or false if closed.
+     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+     * exceptions setting.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentOpenTimeRangeEnd()
+    {
+        /**
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD);
+    }
+
+    /**
+     * Get current open time range start as Carbon instance or false if closed or holiday.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentBusinessTimeRangeStart()
+    {
+        /**
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD, ['isHoliday', false]);
+    }
+
+    /**
+     * Get current open time range end as Carbon instance or false if closed.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
+     */
+    public function getCurrentBusinessOpenTimeRangeEnd()
+    {
+        /**
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD, ['isHoliday', false]);
     }
 
     /**

--- a/src/Cmixin/BusinessTime.php
+++ b/src/Cmixin/BusinessTime.php
@@ -3,343 +3,13 @@
 namespace Cmixin;
 
 use BusinessTime\MixinBase;
+use BusinessTime\Traits\Range;
+use BusinessTime\Traits\IsMethods;
+use BusinessTime\Traits\OpenClose;
 
 class BusinessTime extends MixinBase
 {
-    /**
-     * Get OpeningHoursForDay instance of the current instance or class.
-     *
-     * @return \Closure<\Spatie\OpeningHours\OpeningHoursForDay>
-     */
-    public function getCurrentDayOpeningHours()
-    {
-        /**
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        return function () {
-            $date = isset($this) ? $this : static::now();
-
-            return $date->getOpeningHours()->forDate($date);
-        };
-    }
-
-    /**
-     * Get open time ranges as array of TimeRange instances that matches the current date and time.
-     *
-     * @return \Closure<\Spatie\OpeningHours\TimeRange[]>
-     */
-    public function getCurrentOpenTimeRanges()
-    {
-        /**
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        return function () {
-            $date = isset($this) ? $this : static::now();
-
-            return $date->getOpeningHours()->forDateTime($date);
-        };
-    }
-
-    /**
-     * Get current open time range as TimeRange instance or false if closed.
-     *
-     * @return \Closure<\Spatie\OpeningHours\TimeRange|bool>
-     */
-    public function getCurrentOpenTimeRange()
-    {
-        /**
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        return function () {
-            $date = isset($this) ? $this : static::now();
-
-            return $date->getOpeningHours()->currentOpenRange($date);
-        };
-    }
-
-    /**
-     * Get current open time range start as Carbon instance or false if closed.
-     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
-     */
-    public function getCurrentOpenTimeRangeStart()
-    {
-        /**
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD);
-    }
-
-    /**
-     * Get current open time range end as Carbon instance or false if closed.
-     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
-     */
-    public function getCurrentOpenTimeRangeEnd()
-    {
-        /**
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD);
-    }
-
-    /**
-     * Get current open time range start as Carbon instance or false if closed or holiday.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
-     */
-    public function getCurrentBusinessTimeRangeStart()
-    {
-        /**
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_START_METHOD, ['isHoliday', false]);
-    }
-
-    /**
-     * Get current open time range end as Carbon instance or false if closed.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool>
-     */
-    public function getCurrentBusinessOpenTimeRangeEnd()
-    {
-        /**
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        return $this->getCalleeAsMethod(static::CURRENT_OPEN_RANGE_END_METHOD, ['isHoliday', false]);
-    }
-
-    /**
-     * Returns true if the business is open on a given day according to current opening hours.
-     *
-     * @param string $method can be null or 'isClosedOn' to invert the result
-     *
-     * @return \Closure<bool>
-     */
-    public function isOpenOn($method = null)
-    {
-        $method = preg_replace('/^.*::/', '', $method ?: __METHOD__);
-
-        /**
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        return function ($day) use ($method) {
-            $day = static::normalizeDay($day);
-            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
-
-            return $openingHours->$method($day);
-        };
-    }
-
-    /**
-     * Returns true if the business is closed on a given day according to current opening hours.
-     *
-     * @return \Closure<bool>
-     */
-    public function isClosedOn()
-    {
-        /**
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        return $this->isOpenOn(__METHOD__);
-    }
-
-    /**
-     * Returns true if the business is open now (or current date and time) according to current opening hours.
-     * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @param string $method can be null or 'isClosed' to invert the result
-     *
-     * @return \Closure<bool>
-     */
-    public function isOpen($method = null)
-    {
-        $method = preg_replace('/^.*::/', '', $method ?: __METHOD__).'At';
-
-        /**
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        return function () use ($method) {
-            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
-            $date = isset($this) ? $this : static::now();
-
-            return $openingHours->$method($date);
-        };
-    }
-
-    /**
-     * Returns true if the business is closed now (or current date and time) according to current opening hours.
-     * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @return \Closure<bool>
-     */
-    public function isClosed()
-    {
-        /**
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        return $this->isOpen(__METHOD__);
-    }
-
-    /**
-     * Returns true if the business is open and not an holiday now (or current date and time) according to current
-     * opening hours.
-     *
-     * @return \Closure<bool>
-     */
-    public function isBusinessOpen()
-    {
-        /**
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        return function () {
-            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
-            $date = isset($this) ? $this : static::now();
-
-            return $openingHours->isOpenAt($date) && !$date->isHoliday();
-        };
-    }
-
-    /**
-     * @alias isBusinessOpen
-     *
-     * Returns true if the business is open and not an holiday now (or current date and time) according to current
-     * opening hours.
-     *
-     * @return \Closure<bool>
-     */
-    public function isOpenExcludingHolidays()
-    {
-        /**
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        return $this->isBusinessOpen();
-    }
-
-    /**
-     * Returns true if the business is closed or an holiday now (or current date and time) according to current
-     * opening hours.
-     *
-     * @return \Closure<bool>
-     */
-    public function isBusinessClosed()
-    {
-        /**
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        return function () {
-            $openingHours = isset($this) ? $this->getOpeningHours() : static::getOpeningHours();
-            $date = isset($this) ? $this : static::now();
-
-            return $openingHours->isClosedAt($date) || $date->isHoliday();
-        };
-    }
-
-    /**
-     * @alias isBusinessClosed
-     *
-     * Returns true if the business is closed or an holiday now (or current date and time) according to current
-     * opening hours.
-     *
-     * @return \Closure<bool>
-     */
-    public function isClosedIncludingHolidays()
-    {
-        /**
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        return $this->isBusinessClosed();
-    }
-
-    /**
-     * Go to the next open date and time.
-     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
-     */
-    public function nextOpen()
-    {
-        /**
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        return $this->getCalleeAsMethod(static::NEXT_OPEN_METHOD);
-    }
-
-    /**
-     * Go to the next close date and time.
-     * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-     * exceptions setting.
-     *
-     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
-     */
-    public function nextClose()
-    {
-        /**
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        return $this->getCalleeAsMethod(static::NEXT_CLOSE_METHOD);
-    }
+    use Range, IsMethods, OpenClose;
 
     /**
      * Go to the next open date and time that is also not an holiday.
@@ -372,6 +42,36 @@ class BusinessTime extends MixinBase
     }
 
     /**
+     * Go to the next open date and time that is also not an holiday.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousOpenExcludingHolidays()
+    {
+        /**
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getMethodLoopOnHoliday(static::PREVIOUS_OPEN_METHOD, static::PREVIOUS_OPEN_HOLIDAYS_METHOD);
+    }
+
+    /**
+     * Go to the next open date and time that is also not an holiday.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousBusinessOpen()
+    {
+        /**
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getMethodLoopOnHoliday(static::PREVIOUS_OPEN_METHOD, static::PREVIOUS_OPEN_HOLIDAYS_METHOD);
+    }
+
+    /**
      * Go to the next close date and time or next holiday if sooner.
      *
      * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
@@ -399,5 +99,35 @@ class BusinessTime extends MixinBase
          * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
          */
         return $this->getMethodLoopOnHoliday(static::NEXT_CLOSE_METHOD, static::NEXT_CLOSE_HOLIDAYS_METHOD);
+    }
+
+    /**
+     * Go to the next close date and time or next holiday if sooner.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousCloseIncludingHolidays()
+    {
+        /**
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getMethodLoopOnHoliday(static::PREVIOUS_CLOSE_METHOD, static::PREVIOUS_CLOSE_HOLIDAYS_METHOD);
+    }
+
+    /**
+     * Go to the next close date and time or next holiday if sooner.
+     *
+     * @return \Closure<\Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface>
+     */
+    public function previousBusinessClose()
+    {
+        /**
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        return $this->getMethodLoopOnHoliday(static::PREVIOUS_CLOSE_METHOD, static::PREVIOUS_CLOSE_HOLIDAYS_METHOD);
     }
 }

--- a/tests/Cmixin/BusinessTimeTest.php
+++ b/tests/Cmixin/BusinessTimeTest.php
@@ -411,11 +411,27 @@ class BusinessTimeTest extends TestCase
     public function testEnableWithNoOpeningHours()
     {
         $carbon = static::CARBON_CLASS;
+        $date = $carbon::parse('2019-07-04 10:00');
+
+        self::assertFalse($date->isHoliday());
+
         BusinessTime::enable($carbon, 'us-national');
 
-        $date = $carbon::parse('2019-07-04 10:00');
-        self::assertSame('us-national', $date->getHolidaysRegion());
         self::assertTrue($date->isHoliday());
+    }
+
+    public function testEnableWithNoRegion()
+    {
+        $carbon = static::CARBON_CLASS;
+        BusinessTime::enable($carbon, [
+            'monday'   => ['09:00-12:00', '13:00-18:00'],
+            'holidays' => [
+                'company-special-holiday' => '07/04',
+            ],
+        ]);
+
+        $date = $carbon::parse('2021-04-07 10:00');
+        self::assertTrue($date->isBusinessClosed());
     }
 
     public function testReadmeCode()

--- a/tests/Cmixin/BusinessTimeTest.php
+++ b/tests/Cmixin/BusinessTimeTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Cmixin\BusinessTime;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\OpeningHours;
+use Spatie\OpeningHours\TimeRange;
 
 class BusinessTimeTest extends TestCase
 {
@@ -297,9 +298,8 @@ class BusinessTimeTest extends TestCase
     {
         $carbon = static::CARBON_CLASS;
         $carbon::setTestNow('2018-11-02 08:00:00');
-        $carbon::setHolidaysRegion('fr');
-        $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
-        $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-01 13:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-01 13:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
         $carbon::setTestNow('2018-11-01 09:00:00');
         $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
         $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
@@ -368,6 +368,44 @@ class BusinessTimeTest extends TestCase
         $this->assertSame('', (string) $date->getCurrentDayOpeningHours());
         $date = $carbon::parse('2018-01-02');
         $this->assertSame('09:00-12:00,13:00-18:00', (string) $date->getCurrentDayOpeningHours());
+    }
+
+    public function testGetCurrentOpenTimeRanges()
+    {
+        $carbon = static::CARBON_CLASS;
+        $date = $carbon::parse('2019-07-22 11:45');
+        $list = [];
+
+        foreach ($date->getCurrentOpenTimeRanges() as $range) {
+            self::assertInstanceOf(TimeRange::class, $range);
+            $list[] = (string) $range;
+        }
+
+        self::assertSame(['09:00-12:00'], $list);
+
+        $date = $carbon::parse('2019-07-22 12:45');
+        $list = [];
+
+        foreach ($date->getCurrentOpenTimeRanges() as $range) {
+            self::assertInstanceOf(TimeRange::class, $range);
+            $list[] = (string) $range;
+        }
+
+        self::assertSame([], $list);
+    }
+
+    public function testGetCurrentOpenTimeRange()
+    {
+        $carbon = static::CARBON_CLASS;
+        $date = $carbon::parse('2019-07-22 11:45');
+        $range = $date->getCurrentOpenTimeRange();
+
+        self::assertInstanceOf(TimeRange::class, $range);
+        self::assertSame('09:00-12:00', (string) $range);
+
+        $date = $carbon::parse('2019-07-22 12:45');
+
+        self::assertFalse($date->getCurrentOpenTimeRange());
     }
 
     public function testReadmeCode()

--- a/tests/Cmixin/BusinessTimeTest.php
+++ b/tests/Cmixin/BusinessTimeTest.php
@@ -4,6 +4,7 @@ namespace Tests\Cmixin;
 
 use Carbon\Carbon;
 use Cmixin\BusinessTime;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\OpeningHours;
 use Spatie\OpeningHours\TimeRange;
@@ -12,7 +13,7 @@ class BusinessTimeTest extends TestCase
 {
     const CARBON_CLASS = Carbon::class;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $carbon = static::CARBON_CLASS;
         BusinessTime::enable($carbon, [
@@ -125,22 +126,21 @@ class BusinessTimeTest extends TestCase
         $this->assertInstanceOf(OpeningHours::class, $carbon::convertOpeningHours(OpeningHours::create([])));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Opening hours parameter should be a Spatie\OpeningHours\OpeningHours instance or an array.
-     */
     public function testBadOpeningHoursInput()
     {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Opening hours parameter should be a '.
+            'Spatie\OpeningHours\OpeningHours instance or an array.');
+
         $carbon = static::CARBON_CLASS;
         $carbon::convertOpeningHours($carbon::now());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Opening hours have not be set.
-     */
     public function testUndefinedOpeningHours()
     {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Opening hours have not be set.');
+
         $carbon = static::CARBON_CLASS;
         $carbon::resetOpeningHours();
         BusinessTime::enable($carbon);
@@ -406,6 +406,16 @@ class BusinessTimeTest extends TestCase
         $date = $carbon::parse('2019-07-22 12:45');
 
         self::assertFalse($date->getCurrentOpenTimeRange());
+    }
+
+    public function testEnableWithNoOpeningHours()
+    {
+        $carbon = static::CARBON_CLASS;
+        BusinessTime::enable($carbon, 'us-national');
+
+        $date = $carbon::parse('2019-07-04 10:00');
+        self::assertSame('us-national', $date->getHolidaysRegion());
+        self::assertTrue($date->isHoliday());
     }
 
     public function testReadmeCode()

--- a/tests/Cmixin/BusinessTimeTest.php
+++ b/tests/Cmixin/BusinessTimeTest.php
@@ -40,6 +40,10 @@ class BusinessTimeTest extends TestCase
         $this->assertSame($date, $date->nextClose());
         $this->assertSame($date, $date->nextOpenExcludingHolidays());
         $this->assertSame($date, $date->nextCloseIncludingHolidays());
+        $this->assertSame($date, $date->previousOpen());
+        $this->assertSame($date, $date->previousClose());
+        $this->assertSame($date, $date->previousOpenExcludingHolidays());
+        $this->assertSame($date, $date->previousCloseIncludingHolidays());
     }
 
     public function testIsOpenOn()
@@ -223,6 +227,22 @@ class BusinessTimeTest extends TestCase
         $this->assertSame('2018-11-12 09:00', $carbon::now()->nextOpen()->format('Y-m-d H:i'));
     }
 
+    public function testPreviousOpen()
+    {
+        $carbon = static::CARBON_CLASS;
+        $carbon::setTestNow('2018-11-02 08:00:00');
+        $carbon::setHolidaysRegion('fr');
+        $this->assertSame('2018-11-01 13:00', $carbon::previousOpen()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-01 13:00', $carbon::now()->previousOpen()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-05 09:00:00');
+        $this->assertSame('2018-11-03 13:00', $carbon::previousOpen()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-03 13:00', $carbon::now()->previousOpen()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-11 08:00:00');
+        $this->assertSame('2018-11-10 13:00', $carbon::previousOpen()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-10 13:00', $carbon::now()->previousOpen()->format('Y-m-d H:i'));
+        $carbon::resetHolidays();
+    }
+
     public function testNextClose()
     {
         $carbon = static::CARBON_CLASS;
@@ -235,6 +255,20 @@ class BusinessTimeTest extends TestCase
         $carbon::setTestNow('2018-11-11 08:00:00');
         $this->assertSame('2018-11-12 12:00', $carbon::nextClose()->format('Y-m-d H:i'));
         $this->assertSame('2018-11-12 12:00', $carbon::now()->nextClose()->format('Y-m-d H:i'));
+    }
+
+    public function testPreviousClose()
+    {
+        $carbon = static::CARBON_CLASS;
+        $carbon::setTestNow('2018-11-05 08:00:00');
+        $this->assertSame('2018-11-03 16:00', $carbon::previousClose()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-03 16:00', $carbon::now()->previousClose()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-05 09:00:00');
+        $this->assertSame('2018-11-03 16:00', $carbon::previousClose()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-03 16:00', $carbon::now()->previousClose()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-11 08:00:00');
+        $this->assertSame('2018-11-10 16:00', $carbon::previousClose()->format('Y-m-d H:i'));
+        $this->assertSame('2018-11-10 16:00', $carbon::now()->previousClose()->format('Y-m-d H:i'));
     }
 
     public function testNextOpenExcludingHolidays()
@@ -250,9 +284,33 @@ class BusinessTimeTest extends TestCase
         $carbon::setHolidaysRegion('fr-national');
         $this->assertSame('2018-11-02 09:00', $carbon::nextOpenExcludingHolidays()->format('Y-m-d H:i'));
         $this->assertSame('2018-11-02 09:00', $carbon::now()->nextOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-10-30 22:00:00');
+        $this->assertSame('2018-10-31 09:00', $carbon::nextOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-10-31 09:00', $carbon::now()->nextOpenExcludingHolidays()->format('Y-m-d H:i'));
         $carbon::setTestNow('2018-11-02 09:00:00');
         $this->assertSame('2018-11-02 13:00', $carbon::nextOpenExcludingHolidays()->format('Y-m-d H:i'));
         $this->assertSame('2018-11-02 13:00', $carbon::now()->nextOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $carbon::resetHolidays();
+    }
+
+    public function testPreviousOpenExcludingHolidays()
+    {
+        $carbon = static::CARBON_CLASS;
+        $carbon::setTestNow('2018-11-02 08:00:00');
+        $carbon::setHolidaysRegion('fr');
+        $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-01 09:00:00');
+        $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+
+        $carbon::setHolidaysRegion('fr-national');
+        $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $carbon::setTestNow('2018-11-02 09:00:00');
+        $this->assertSame('2018-10-31 09:00', $carbon::previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $this->assertSame('2018-10-31 09:00', $carbon::now()->previousOpenExcludingHolidays()->format('Y-m-d H:i'));
+        $carbon::resetHolidays();
     }
 
     public function testNextCloseIncludingHolidays()

--- a/types/_ide_business_time_instantiated.php
+++ b/types/_ide_business_time_instantiated.php
@@ -7,13 +7,89 @@ namespace Carbon
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -25,7 +101,7 @@ namespace Carbon
          */
         public function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -37,7 +113,7 @@ namespace Carbon
          */
         public function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -51,7 +127,7 @@ namespace Carbon
          */
         public function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -65,7 +141,7 @@ namespace Carbon
          */
         public function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -78,7 +154,7 @@ namespace Carbon
          */
         public function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -93,7 +169,7 @@ namespace Carbon
          */
         public function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -106,7 +182,7 @@ namespace Carbon
          */
         public function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -121,7 +197,7 @@ namespace Carbon
          */
         public function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -135,7 +211,7 @@ namespace Carbon
          */
         public function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -149,7 +225,7 @@ namespace Carbon
          */
         public function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -161,7 +237,7 @@ namespace Carbon
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -173,7 +249,7 @@ namespace Carbon
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -185,7 +261,7 @@ namespace Carbon
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -197,7 +273,7 @@ namespace Carbon
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -212,7 +288,7 @@ namespace Carbon
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -230,7 +306,7 @@ namespace Carbon
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -248,7 +324,7 @@ namespace Carbon
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -262,7 +338,7 @@ namespace Carbon
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -274,7 +350,7 @@ namespace Carbon
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -288,7 +364,7 @@ namespace Carbon
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -300,7 +376,7 @@ namespace Carbon
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -315,7 +391,7 @@ namespace Carbon
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -330,7 +406,7 @@ namespace Carbon
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -342,13 +418,89 @@ namespace Carbon
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -360,7 +512,7 @@ namespace Carbon
          */
         public function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -372,7 +524,7 @@ namespace Carbon
          */
         public function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -386,7 +538,7 @@ namespace Carbon
          */
         public function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -400,7 +552,7 @@ namespace Carbon
          */
         public function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -413,7 +565,7 @@ namespace Carbon
          */
         public function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -428,7 +580,7 @@ namespace Carbon
          */
         public function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -441,7 +593,7 @@ namespace Carbon
          */
         public function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -456,7 +608,7 @@ namespace Carbon
          */
         public function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -470,7 +622,7 @@ namespace Carbon
          */
         public function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -484,7 +636,7 @@ namespace Carbon
          */
         public function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -496,7 +648,7 @@ namespace Carbon
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -508,7 +660,7 @@ namespace Carbon
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -520,7 +672,7 @@ namespace Carbon
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -532,7 +684,7 @@ namespace Carbon
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -547,7 +699,7 @@ namespace Carbon
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -565,7 +717,7 @@ namespace Carbon
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -583,7 +735,7 @@ namespace Carbon
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -597,7 +749,7 @@ namespace Carbon
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -609,7 +761,7 @@ namespace Carbon
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -623,7 +775,7 @@ namespace Carbon
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -635,7 +787,7 @@ namespace Carbon
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -650,7 +802,7 @@ namespace Carbon
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -665,7 +817,7 @@ namespace Carbon
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -677,13 +829,89 @@ namespace Illuminate\Support
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -695,7 +923,7 @@ namespace Illuminate\Support
          */
         public function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -707,7 +935,7 @@ namespace Illuminate\Support
          */
         public function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -721,7 +949,7 @@ namespace Illuminate\Support
          */
         public function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -735,7 +963,7 @@ namespace Illuminate\Support
          */
         public function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -748,7 +976,7 @@ namespace Illuminate\Support
          */
         public function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -763,7 +991,7 @@ namespace Illuminate\Support
          */
         public function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -776,7 +1004,7 @@ namespace Illuminate\Support
          */
         public function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -791,7 +1019,7 @@ namespace Illuminate\Support
          */
         public function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -805,7 +1033,7 @@ namespace Illuminate\Support
          */
         public function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -819,7 +1047,7 @@ namespace Illuminate\Support
          */
         public function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -831,7 +1059,7 @@ namespace Illuminate\Support
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -843,7 +1071,7 @@ namespace Illuminate\Support
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -855,7 +1083,7 @@ namespace Illuminate\Support
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -867,7 +1095,7 @@ namespace Illuminate\Support
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -882,7 +1110,7 @@ namespace Illuminate\Support
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -900,7 +1128,7 @@ namespace Illuminate\Support
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -918,7 +1146,7 @@ namespace Illuminate\Support
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -932,7 +1160,7 @@ namespace Illuminate\Support
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -944,7 +1172,7 @@ namespace Illuminate\Support
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -958,7 +1186,7 @@ namespace Illuminate\Support
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -970,7 +1198,7 @@ namespace Illuminate\Support
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -985,7 +1213,7 @@ namespace Illuminate\Support
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1000,7 +1228,7 @@ namespace Illuminate\Support
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -1012,13 +1240,89 @@ namespace Illuminate\Support\Facades
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1030,7 +1334,7 @@ namespace Illuminate\Support\Facades
          */
         public function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -1042,7 +1346,7 @@ namespace Illuminate\Support\Facades
          */
         public function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -1056,7 +1360,7 @@ namespace Illuminate\Support\Facades
          */
         public function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -1070,7 +1374,7 @@ namespace Illuminate\Support\Facades
          */
         public function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -1083,7 +1387,7 @@ namespace Illuminate\Support\Facades
          */
         public function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -1098,7 +1402,7 @@ namespace Illuminate\Support\Facades
          */
         public function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -1111,7 +1415,7 @@ namespace Illuminate\Support\Facades
          */
         public function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -1126,7 +1430,7 @@ namespace Illuminate\Support\Facades
          */
         public function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -1140,7 +1444,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1154,7 +1458,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1166,7 +1470,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1178,7 +1482,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1190,7 +1494,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1202,7 +1506,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1217,7 +1521,7 @@ namespace Illuminate\Support\Facades
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -1235,7 +1539,7 @@ namespace Illuminate\Support\Facades
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -1253,7 +1557,7 @@ namespace Illuminate\Support\Facades
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -1267,7 +1571,7 @@ namespace Illuminate\Support\Facades
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -1279,7 +1583,7 @@ namespace Illuminate\Support\Facades
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -1293,7 +1597,7 @@ namespace Illuminate\Support\Facades
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -1305,7 +1609,7 @@ namespace Illuminate\Support\Facades
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -1320,7 +1624,7 @@ namespace Illuminate\Support\Facades
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1335,7 +1639,7 @@ namespace Illuminate\Support\Facades
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }

--- a/types/_ide_business_time_instantiated.php
+++ b/types/_ide_business_time_instantiated.php
@@ -5,230 +5,6 @@ namespace Carbon
     class Carbon
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -237,7 +13,7 @@ namespace Carbon
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -249,7 +25,31 @@ namespace Carbon
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -261,7 +61,7 @@ namespace Carbon
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -273,7 +73,31 @@ namespace Carbon
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -288,7 +112,7 @@ namespace Carbon
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -306,7 +130,7 @@ namespace Carbon
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -324,7 +148,7 @@ namespace Carbon
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -338,7 +162,7 @@ namespace Carbon
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -350,7 +174,7 @@ namespace Carbon
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -364,7 +188,7 @@ namespace Carbon
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -376,7 +200,7 @@ namespace Carbon
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -391,7 +215,7 @@ namespace Carbon
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -406,7 +230,267 @@ namespace Carbon
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -416,230 +500,6 @@ namespace Carbon
     class CarbonImmutable
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -648,7 +508,7 @@ namespace Carbon
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -660,7 +520,31 @@ namespace Carbon
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -672,7 +556,7 @@ namespace Carbon
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -684,7 +568,31 @@ namespace Carbon
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -699,7 +607,7 @@ namespace Carbon
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -717,7 +625,7 @@ namespace Carbon
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -735,7 +643,7 @@ namespace Carbon
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -749,7 +657,7 @@ namespace Carbon
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -761,7 +669,7 @@ namespace Carbon
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -775,7 +683,7 @@ namespace Carbon
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -787,7 +695,7 @@ namespace Carbon
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -802,7 +710,7 @@ namespace Carbon
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -817,7 +725,267 @@ namespace Carbon
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -827,230 +995,6 @@ namespace Illuminate\Support
     class Carbon
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -1059,7 +1003,7 @@ namespace Illuminate\Support
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1071,7 +1015,31 @@ namespace Illuminate\Support
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1083,7 +1051,7 @@ namespace Illuminate\Support
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1095,7 +1063,31 @@ namespace Illuminate\Support
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1110,7 +1102,7 @@ namespace Illuminate\Support
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -1128,7 +1120,7 @@ namespace Illuminate\Support
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -1146,7 +1138,7 @@ namespace Illuminate\Support
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -1160,7 +1152,7 @@ namespace Illuminate\Support
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -1172,7 +1164,7 @@ namespace Illuminate\Support
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -1186,7 +1178,7 @@ namespace Illuminate\Support
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -1198,7 +1190,7 @@ namespace Illuminate\Support
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -1213,7 +1205,7 @@ namespace Illuminate\Support
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -1228,7 +1220,267 @@ namespace Illuminate\Support
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -1238,230 +1490,6 @@ namespace Illuminate\Support\Facades
     class Date
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -1470,7 +1498,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1482,7 +1510,31 @@ namespace Illuminate\Support\Facades
          */
         public function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1494,7 +1546,7 @@ namespace Illuminate\Support\Facades
          */
         public function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1506,7 +1558,31 @@ namespace Illuminate\Support\Facades
          */
         public function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1521,7 +1597,7 @@ namespace Illuminate\Support\Facades
          */
         public function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -1539,7 +1615,7 @@ namespace Illuminate\Support\Facades
          */
         public function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -1557,7 +1633,7 @@ namespace Illuminate\Support\Facades
          */
         public function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -1571,7 +1647,7 @@ namespace Illuminate\Support\Facades
          */
         public function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -1583,7 +1659,7 @@ namespace Illuminate\Support\Facades
          */
         public function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -1597,7 +1673,7 @@ namespace Illuminate\Support\Facades
          */
         public function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -1609,7 +1685,7 @@ namespace Illuminate\Support\Facades
          */
         public function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -1624,7 +1700,7 @@ namespace Illuminate\Support\Facades
          */
         public function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -1639,7 +1715,267 @@ namespace Illuminate\Support\Facades
          */
         public function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }

--- a/types/_ide_business_time_static.php
+++ b/types/_ide_business_time_static.php
@@ -5,230 +5,6 @@ namespace Carbon
     class Carbon
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public static function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public static function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public static function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -237,7 +13,7 @@ namespace Carbon
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -249,7 +25,31 @@ namespace Carbon
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -261,7 +61,7 @@ namespace Carbon
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -273,7 +73,31 @@ namespace Carbon
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -288,7 +112,7 @@ namespace Carbon
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -306,7 +130,7 @@ namespace Carbon
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -324,7 +148,7 @@ namespace Carbon
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -338,7 +162,7 @@ namespace Carbon
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -350,7 +174,7 @@ namespace Carbon
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -364,7 +188,7 @@ namespace Carbon
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -376,7 +200,7 @@ namespace Carbon
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -391,7 +215,7 @@ namespace Carbon
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -406,7 +230,267 @@ namespace Carbon
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public static function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -416,230 +500,6 @@ namespace Carbon
     class CarbonImmutable
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public static function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public static function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public static function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -648,7 +508,7 @@ namespace Carbon
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -660,7 +520,31 @@ namespace Carbon
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -672,7 +556,7 @@ namespace Carbon
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -684,7 +568,31 @@ namespace Carbon
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -699,7 +607,7 @@ namespace Carbon
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -717,7 +625,7 @@ namespace Carbon
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -735,7 +643,7 @@ namespace Carbon
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -749,7 +657,7 @@ namespace Carbon
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -761,7 +669,7 @@ namespace Carbon
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -775,7 +683,7 @@ namespace Carbon
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -787,7 +695,7 @@ namespace Carbon
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -802,7 +710,7 @@ namespace Carbon
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -817,7 +725,267 @@ namespace Carbon
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public static function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -827,230 +995,6 @@ namespace Illuminate\Support
     class Carbon
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public static function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public static function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public static function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -1059,7 +1003,7 @@ namespace Illuminate\Support
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1071,7 +1015,31 @@ namespace Illuminate\Support
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1083,7 +1051,7 @@ namespace Illuminate\Support
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1095,7 +1063,31 @@ namespace Illuminate\Support
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1110,7 +1102,7 @@ namespace Illuminate\Support
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -1128,7 +1120,7 @@ namespace Illuminate\Support
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -1146,7 +1138,7 @@ namespace Illuminate\Support
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -1160,7 +1152,7 @@ namespace Illuminate\Support
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -1172,7 +1164,7 @@ namespace Illuminate\Support
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -1186,7 +1178,7 @@ namespace Illuminate\Support
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -1198,7 +1190,7 @@ namespace Illuminate\Support
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -1213,7 +1205,7 @@ namespace Illuminate\Support
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -1228,7 +1220,267 @@ namespace Illuminate\Support
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public static function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }
@@ -1238,230 +1490,6 @@ namespace Illuminate\Support\Facades
     class Date
     {
         /**
-         * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
-         *
-         * Get OpeningHoursForDay instance of the current instance or class.
-         *
-         * @return \Spatie\OpeningHours\OpeningHoursForDay
-         */
-        public static function getCurrentDayOpeningHours()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:21
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
-         *
-         * Get open time ranges as array of TimeRange instances that matches the current date and time.
-         *
-         * @return \Spatie\OpeningHours\TimeRange[]
-         */
-        public static function getCurrentOpenTimeRanges()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:40
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
-         *
-         * Get current open time range as TimeRange instance or false if closed.
-         *
-         * @return \Spatie\OpeningHours\TimeRange|bool
-         */
-        public static function getCurrentOpenTimeRange()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:59
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
-         *
-         * Get current open time range start as Carbon instance or false if closed or holiday.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessTimeRangeStart($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
-         *
-         * Get current open time range end as Carbon instance or false if closed.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
-         */
-        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenOn
-         *
-         * Returns true if the business is open on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedOn
-         *
-         * Returns true if the business is closed on a given day according to current opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedOn($day)
-        {
-            // Content, see src/Cmixin/BusinessTime.php:150
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpen
-         *
-         * Returns true if the business is open now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosed
-         *
-         * Returns true if the business is closed now (or current date and time) according to current opening hours.
-         * /!\ Important: it returns false if the current day is an holiday unless you set a closure handler for it in
-         * the exceptions setting.
-         *
-         * @return bool
-         */
-        public static function isClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:193
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessOpen()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isOpenExcludingHolidays
-         *
-         * @alias isBusinessOpen
-         *
-         * Returns true if the business is open and not an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isOpenExcludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:234
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isBusinessClosed()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \Cmixin\BusinessTime::isClosedIncludingHolidays
-         *
-         * @alias isBusinessClosed
-         *
-         * Returns true if the business is closed or an holiday now (or current date and time) according to current
-         * opening hours.
-         *
-         * @return bool
-         */
-        public static function isClosedIncludingHolidays()
-        {
-            // Content, see src/Cmixin/BusinessTime.php:277
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextOpen
-         *
-         * Go to the next open date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextOpen($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
-         * @see \BusinessTime\MixinBase::nextClose
-         *
-         * Go to the next close date and time.
-         * /!\ Important: holidays are assumed open unless you set a closure handler for it in the
-         * exceptions setting.
-         *
-         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
-         */
-        public static function nextClose($method = null)
-        {
-            // Content, see src/BusinessTime/MixinBase.php:314
-        }
-
-        /**
          * @see \BusinessTime\MixinBase::nextOpenExcludingHolidays
          *
          * Go to the next open date and time that is also not an holiday.
@@ -1470,7 +1498,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1482,7 +1510,31 @@ namespace Illuminate\Support\Facades
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpenExcludingHolidays
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessOpen
+         *
+         * Go to the next open date and time that is also not an holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessOpen()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1494,7 +1546,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1506,7 +1558,31 @@ namespace Illuminate\Support\Facades
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousCloseIncludingHolidays
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousCloseIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousBusinessClose
+         *
+         * Go to the next close date and time or next holiday if sooner.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousBusinessClose()
+        {
+            // Content, see src/BusinessTime/MixinBase.php:348
         }
 
         /**
@@ -1521,7 +1597,7 @@ namespace Illuminate\Support\Facades
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:61
+            // Content, see src/BusinessTime/MixinBase.php:65
         }
 
         /**
@@ -1539,7 +1615,7 @@ namespace Illuminate\Support\Facades
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:94
+            // Content, see src/BusinessTime/MixinBase.php:98
         }
 
         /**
@@ -1557,7 +1633,7 @@ namespace Illuminate\Support\Facades
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:118
+            // Content, see src/BusinessTime/MixinBase.php:122
         }
 
         /**
@@ -1571,7 +1647,7 @@ namespace Illuminate\Support\Facades
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:179
+            // Content, see src/BusinessTime/MixinBase.php:183
         }
 
         /**
@@ -1583,7 +1659,7 @@ namespace Illuminate\Support\Facades
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:222
+            // Content, see src/BusinessTime/MixinBase.php:226
         }
 
         /**
@@ -1597,7 +1673,7 @@ namespace Illuminate\Support\Facades
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:260
+            // Content, see src/BusinessTime/MixinBase.php:264
         }
 
         /**
@@ -1609,7 +1685,7 @@ namespace Illuminate\Support\Facades
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:288
+            // Content, see src/BusinessTime/MixinBase.php:292
         }
 
         /**
@@ -1624,7 +1700,7 @@ namespace Illuminate\Support\Facades
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:314
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
 
         /**
@@ -1639,7 +1715,267 @@ namespace Illuminate\Support\Facades
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:353
+            // Content, see src/BusinessTime/MixinBase.php:348
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentDayOpeningHours
+         *
+         * Get OpeningHoursForDay instance of the current instance or class.
+         *
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
+         */
+        public static function getCurrentDayOpeningHours()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:21
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:41
+        }
+
+        /**
+         * @see \BusinessTime\Traits\Range::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/BusinessTime/Traits/Range.php:61
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedOn
+         *
+         * Returns true if the business is open on a given day according to current opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedOn($day)
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:23
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpen
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosed
+         *
+         * Returns true if the business is open now (or current date and time) according to current opening hours.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in
+         * the exceptions setting.
+         *
+         * @return bool
+         */
+        public static function isClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:66
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessOpen
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessOpen()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isOpenExcludingHolidays
+         *
+         * Returns true if the business is open and not an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isOpenExcludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:107
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isBusinessClosed
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isBusinessClosed()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\Traits\IsMethods::isClosedIncludingHolidays
+         *
+         * Returns true if the business is closed or an holiday now (or current date and time) according to current
+         * opening hours.
+         *
+         * @return bool
+         */
+        public static function isClosedIncludingHolidays()
+        {
+            // Content, see src/BusinessTime/Traits/IsMethods.php:150
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::nextClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function nextClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousOpen
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousOpen($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::previousClose
+         *
+         * Get a closure to be executed on OpeningHours on the current instance (or now if called globally) that should
+         * return a date, then convert it into a Carbon/sub-class instance.
+         *
+         * @param string $method
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface
+         */
+        public static function previousClose($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:317
         }
     }
 }

--- a/types/_ide_business_time_static.php
+++ b/types/_ide_business_time_static.php
@@ -7,13 +7,89 @@ namespace Carbon
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public static function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -25,7 +101,7 @@ namespace Carbon
          */
         public static function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -37,7 +113,7 @@ namespace Carbon
          */
         public static function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -51,7 +127,7 @@ namespace Carbon
          */
         public static function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -65,7 +141,7 @@ namespace Carbon
          */
         public static function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -78,7 +154,7 @@ namespace Carbon
          */
         public static function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -93,7 +169,7 @@ namespace Carbon
          */
         public static function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -106,7 +182,7 @@ namespace Carbon
          */
         public static function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -121,7 +197,7 @@ namespace Carbon
          */
         public static function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -135,7 +211,7 @@ namespace Carbon
          */
         public static function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -149,7 +225,7 @@ namespace Carbon
          */
         public static function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -161,7 +237,7 @@ namespace Carbon
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -173,7 +249,7 @@ namespace Carbon
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -185,7 +261,7 @@ namespace Carbon
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -197,7 +273,7 @@ namespace Carbon
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -212,7 +288,7 @@ namespace Carbon
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -230,7 +306,7 @@ namespace Carbon
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -248,7 +324,7 @@ namespace Carbon
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -262,7 +338,7 @@ namespace Carbon
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -274,7 +350,7 @@ namespace Carbon
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -288,7 +364,7 @@ namespace Carbon
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -300,7 +376,7 @@ namespace Carbon
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -315,7 +391,7 @@ namespace Carbon
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -330,7 +406,7 @@ namespace Carbon
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -342,13 +418,89 @@ namespace Carbon
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public static function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -360,7 +512,7 @@ namespace Carbon
          */
         public static function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -372,7 +524,7 @@ namespace Carbon
          */
         public static function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -386,7 +538,7 @@ namespace Carbon
          */
         public static function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -400,7 +552,7 @@ namespace Carbon
          */
         public static function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -413,7 +565,7 @@ namespace Carbon
          */
         public static function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -428,7 +580,7 @@ namespace Carbon
          */
         public static function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -441,7 +593,7 @@ namespace Carbon
          */
         public static function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -456,7 +608,7 @@ namespace Carbon
          */
         public static function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -470,7 +622,7 @@ namespace Carbon
          */
         public static function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -484,7 +636,7 @@ namespace Carbon
          */
         public static function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -496,7 +648,7 @@ namespace Carbon
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -508,7 +660,7 @@ namespace Carbon
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -520,7 +672,7 @@ namespace Carbon
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -532,7 +684,7 @@ namespace Carbon
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -547,7 +699,7 @@ namespace Carbon
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -565,7 +717,7 @@ namespace Carbon
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -583,7 +735,7 @@ namespace Carbon
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -597,7 +749,7 @@ namespace Carbon
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -609,7 +761,7 @@ namespace Carbon
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -623,7 +775,7 @@ namespace Carbon
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -635,7 +787,7 @@ namespace Carbon
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -650,7 +802,7 @@ namespace Carbon
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -665,7 +817,7 @@ namespace Carbon
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -677,13 +829,89 @@ namespace Illuminate\Support
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public static function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -695,7 +923,7 @@ namespace Illuminate\Support
          */
         public static function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -707,7 +935,7 @@ namespace Illuminate\Support
          */
         public static function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -721,7 +949,7 @@ namespace Illuminate\Support
          */
         public static function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -735,7 +963,7 @@ namespace Illuminate\Support
          */
         public static function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -748,7 +976,7 @@ namespace Illuminate\Support
          */
         public static function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -763,7 +991,7 @@ namespace Illuminate\Support
          */
         public static function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -776,7 +1004,7 @@ namespace Illuminate\Support
          */
         public static function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -791,7 +1019,7 @@ namespace Illuminate\Support
          */
         public static function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -805,7 +1033,7 @@ namespace Illuminate\Support
          */
         public static function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -819,7 +1047,7 @@ namespace Illuminate\Support
          */
         public static function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -831,7 +1059,7 @@ namespace Illuminate\Support
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -843,7 +1071,7 @@ namespace Illuminate\Support
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -855,7 +1083,7 @@ namespace Illuminate\Support
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -867,7 +1095,7 @@ namespace Illuminate\Support
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -882,7 +1110,7 @@ namespace Illuminate\Support
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -900,7 +1128,7 @@ namespace Illuminate\Support
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -918,7 +1146,7 @@ namespace Illuminate\Support
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -932,7 +1160,7 @@ namespace Illuminate\Support
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -944,7 +1172,7 @@ namespace Illuminate\Support
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -958,7 +1186,7 @@ namespace Illuminate\Support
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -970,7 +1198,7 @@ namespace Illuminate\Support
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -985,7 +1213,7 @@ namespace Illuminate\Support
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1000,7 +1228,7 @@ namespace Illuminate\Support
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }
@@ -1012,13 +1240,89 @@ namespace Illuminate\Support\Facades
         /**
          * @see \Cmixin\BusinessTime::getCurrentDayOpeningHours
          *
-         * Get OpeningHours instance of the current instance or class.
+         * Get OpeningHoursForDay instance of the current instance or class.
          *
-         * @return \Spatie\OpeningHours\OpeningHours
+         * @return \Spatie\OpeningHours\OpeningHoursForDay
          */
         public static function getCurrentDayOpeningHours()
         {
             // Content, see src/Cmixin/BusinessTime.php:21
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRanges
+         *
+         * Get open time ranges as array of TimeRange instances that matches the current date and time.
+         *
+         * @return \Spatie\OpeningHours\TimeRange[]
+         */
+        public static function getCurrentOpenTimeRanges()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:40
+        }
+
+        /**
+         * @see \Cmixin\BusinessTime::getCurrentOpenTimeRange
+         *
+         * Get current open time range as TimeRange instance or false if closed.
+         *
+         * @return \Spatie\OpeningHours\TimeRange|bool
+         */
+        public static function getCurrentOpenTimeRange()
+        {
+            // Content, see src/Cmixin/BusinessTime.php:59
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         * /!\ Important: it returns true if the current day is an holiday unless you set a closure handler for it in the
+         * exceptions setting.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessTimeRangeStart
+         *
+         * Get current open time range start as Carbon instance or false if closed or holiday.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessTimeRangeStart($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
+        }
+
+        /**
+         * @see \BusinessTime\MixinBase::getCurrentBusinessOpenTimeRangeEnd
+         *
+         * Get current open time range end as Carbon instance or false if closed.
+         *
+         * @return \Carbon\Carbon|\Carbon\CarbonImmutable|\Carbon\CarbonInterface|bool
+         */
+        public static function getCurrentBusinessOpenTimeRangeEnd($method = null)
+        {
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1030,7 +1334,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isOpenOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -1042,7 +1346,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isClosedOn($day)
         {
-            // Content, see src/Cmixin/BusinessTime.php:44
+            // Content, see src/Cmixin/BusinessTime.php:150
         }
 
         /**
@@ -1056,7 +1360,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -1070,7 +1374,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:87
+            // Content, see src/Cmixin/BusinessTime.php:193
         }
 
         /**
@@ -1083,7 +1387,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isBusinessOpen()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -1098,7 +1402,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isOpenExcludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:128
+            // Content, see src/Cmixin/BusinessTime.php:234
         }
 
         /**
@@ -1111,7 +1415,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isBusinessClosed()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -1126,7 +1430,7 @@ namespace Illuminate\Support\Facades
          */
         public static function isClosedIncludingHolidays()
         {
-            // Content, see src/Cmixin/BusinessTime.php:171
+            // Content, see src/Cmixin/BusinessTime.php:277
         }
 
         /**
@@ -1140,7 +1444,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextOpen($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1154,7 +1458,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextClose($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1166,7 +1470,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextOpenExcludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1178,7 +1482,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextBusinessOpen()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1190,7 +1494,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextCloseIncludingHolidays()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1202,7 +1506,7 @@ namespace Illuminate\Support\Facades
          */
         public static function nextBusinessClose()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
 
         /**
@@ -1217,7 +1521,7 @@ namespace Illuminate\Support\Facades
          */
         public static function normalizeDay($day)
         {
-            // Content, see src/BusinessTime/MixinBase.php:59
+            // Content, see src/BusinessTime/MixinBase.php:61
         }
 
         /**
@@ -1235,7 +1539,7 @@ namespace Illuminate\Support\Facades
          */
         public static function convertOpeningHours($defaultOpeningHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:92
+            // Content, see src/BusinessTime/MixinBase.php:94
         }
 
         /**
@@ -1253,7 +1557,7 @@ namespace Illuminate\Support\Facades
          */
         public static function enable()
         {
-            // Content, see src/BusinessTime/MixinBase.php:116
+            // Content, see src/BusinessTime/MixinBase.php:118
         }
 
         /**
@@ -1267,7 +1571,7 @@ namespace Illuminate\Support\Facades
          */
         public static function setOpeningHours($openingHours)
         {
-            // Content, see src/BusinessTime/MixinBase.php:177
+            // Content, see src/BusinessTime/MixinBase.php:179
         }
 
         /**
@@ -1279,7 +1583,7 @@ namespace Illuminate\Support\Facades
          */
         public static function resetOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:220
+            // Content, see src/BusinessTime/MixinBase.php:222
         }
 
         /**
@@ -1293,7 +1597,7 @@ namespace Illuminate\Support\Facades
          */
         public static function getOpeningHours()
         {
-            // Content, see src/BusinessTime/MixinBase.php:258
+            // Content, see src/BusinessTime/MixinBase.php:260
         }
 
         /**
@@ -1305,7 +1609,7 @@ namespace Illuminate\Support\Facades
          */
         public static function safeCallOnOpeningHours($method, ...$arguments)
         {
-            // Content, see src/BusinessTime/MixinBase.php:286
+            // Content, see src/BusinessTime/MixinBase.php:288
         }
 
         /**
@@ -1320,7 +1624,7 @@ namespace Illuminate\Support\Facades
          */
         public static function getCalleeAsMethod($method = null)
         {
-            // Content, see src/BusinessTime/MixinBase.php:311
+            // Content, see src/BusinessTime/MixinBase.php:314
         }
 
         /**
@@ -1335,7 +1639,7 @@ namespace Illuminate\Support\Facades
          */
         public static function getMethodLoopOnHoliday()
         {
-            // Content, see src/BusinessTime/MixinBase.php:341
+            // Content, see src/BusinessTime/MixinBase.php:353
         }
     }
 }


### PR DESCRIPTION
Implement methods from:
https://github.com/spatie/opening-hours/pull/131

- previousOpen
- previousClose
- previousBusinessOpen / previousOpenExcludingHolidays
- previousBusinessClose / previousCloseIncludingHolidays
- getCurrentOpenTimeRanges
- getCurrentOpenTimeRange
- getCurrentOpenTimeRangeStart
- getCurrentOpenTimeRangeEnd
- getCurrentBusinessTimeRangeStart
- getCurrentBusinessTimeRangeEnd

To do:
- [x] Upgrade spatie/opening-hours to 2.6.0 when released
- [x] Document methods
- [x] Add unit tests