### PR TITLE
Add php-7.4 version test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
   - php: 7.3
     env: setup=lowest
   - php: 7.3
+  - php: 7.4
+    env: setup=lowest
+  - php: 7.4
     env: coverage=true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "require": {
     "php": ">=7.1",
     "cmixin/business-day": "^1.1",
-    "nesbot/carbon": "^2.0",
+    "nesbot/carbon": "^2.28",
     "spatie/opening-hours": "^2.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
+    "phpunit/phpunit": "^7.0 || ^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Cmixin/BusinessTime.php
+++ b/src/Cmixin/BusinessTime.php
@@ -9,8 +9,9 @@ use BusinessTime\Traits\Range;
 
 class BusinessTime extends MixinBase
 {
-    use Range, IsMethods, OpenClose;
-
+    use Range;
+    use IsMethods;
+    use OpenClose;
     /**
      * Go to the next open date and time that is also not an holiday.
      *


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.
- Using the `^2.28` version for `Carbon` package to be compatible with `php-7.4` version on `composer` `lowest` work.