### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use Cmixin\BusinessTime;
 
 BusinessTime::enable(Carbon::class);
 // Or if you use Laravel:
-// BusinessDay::enable('Illuminate\Support\Carbon');
+// BusinessTime::enable('Illuminate\Support\Carbon');
 
 // And you can enable multiple classes at once:
 BusinessTime::enable([
@@ -758,16 +758,25 @@ To enable business-time globally in Laravel, set default openning hours and holi
 
 ```php
 <?php return [
-  'opening-hours' => [
-    'monday' => ['08:00-12:00', '14:00-19:00'],
-    'wednesday' => ['09:00-19:00'],
-  ],
-  'holidaysAreClosed' => true,
-  'holidays' => [
+    'monday' => ['09:00-12:00', '13:00-18:00'],
+    'tuesday' => ['09:00-12:00', '13:00-18:00'],
+    'wednesday' => ['09:00-12:00'],
+    'thursday' => ['09:00-12:00', '13:00-18:00'],
+    'friday' => ['09:00-12:00', '13:00-20:00'],
+    'saturday' => ['09:00-12:00', '13:00-16:00'],
+    'sunday' => [],
+    'exceptions' => [
+        '2016-11-11' => ['09:00-12:00'],
+        '2016-12-25' => [],
+        '01-01' => [], // Recurring on each 1st of january
+        '12-25' => ['09:00-12:00'], // Recurring on each 25th of december
+    ],
+    'holidaysAreClosed' => true,
+    'holidays' => [
     'region' => 'us',
     'with' => [
-      'boss-birthday' => '09-26',
-      'last-monday'   => '= last Monday of October',
+        'boss-birthday' => '09-26',
+        'last-monday' => '= last Monday of October',
     ],
   ],
 ];


### PR DESCRIPTION
There were some errors in the readme file.
1. The enable should be for 'Time' not 'Day'.
2. The example laravel carbon.php was in the wrong format and caused "Spatie\OpeningHours\Exceptions\InvalidDayName: Day `opening-hours` isn't a valid day name. Valid day names are lowercase english words, e.g. `monday`, `thursday`."